### PR TITLE
Fix for methods named "set"

### DIFF
--- a/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
+++ b/src/main/java/com/alibaba/fastjson/util/JavaBeanInfo.java
@@ -690,6 +690,10 @@ public class JavaBeanInfo {
                 continue;
             }
 
+            if (methodName.equals("set")) {
+                continue;
+            }
+
             char c3 = methodName.charAt(3);
 
             String propertyName;


### PR DESCRIPTION
Otherwise, if a method exists with name `set()` it throws a `java.lang.StringIndexOutOfBoundsException: String index out of range: 3` exception.